### PR TITLE
feat: add configurable Enter execution for executables and Ctrl+O terminal access

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ theme = "catppuccin-mocha"
 enter_action = "edit"
 # What Space does on a file: "preview" or "edit"
 space_action = "preview"
+# Whether to ask for confirmation before executing a file.
+confirm_execute = true
+# Whether to pause and wait after execution before returning to Midday Commander.
+pause_after_execute = false
 
 [keys]
 quit          = ["f10", "ctrl+c"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Midday Commander (mdc) brings the classic dual-panel file management paradigm in
 - **Multi-file selection** - tag files with Insert or Shift+Arrow for batch operations
 - **Quick search** - start typing to jump to matching files instantly
 - **External editor/viewer** - opens files in `$EDITOR` and `$PAGER`
+- **Execute files** - run executable files directly with Enter (configurable)
+- **Terminal access** - open shell in current directory with Ctrl+O
 - **Mouse support** - clickable menu bar and panel interaction
 - **Go to path** - quickly jump to any directory with `~` expansion
 - **Single binary** - no runtime dependencies
@@ -159,7 +161,7 @@ cp config.example.toml ~/.config/mdc/config.toml
 theme = "catppuccin-mocha"
 
 [behavior]
-# What Enter does on a file: "edit" or "preview"
+# What Enter does on a file: "edit", "preview", or "execute"
 enter_action = "edit"
 # What Space does on a file: "preview" or "edit"
 space_action = "preview"
@@ -175,6 +177,7 @@ fuzzy_find    = ["f9", "ctrl+p"]
 bookmarks     = ["f2", "ctrl+b"]
 help          = "f1"
 goto          = "ctrl+g"
+terminal      = "ctrl+o"
 # ... all keys are configurable
 ```
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,7 +8,7 @@ theme = "catppuccin-mocha"
 
 # ─── Behavior ────────────────────────────────────
 [behavior]
-# What Enter does on a file: "edit" or "preview"
+# What Enter does on a file: "edit", "preview", or "execute"
 enter_action = "edit"
 # What Space does on a file: "preview" or "edit"
 space_action = "preview"
@@ -46,3 +46,12 @@ select_down   = "shift+down"
 
 # Search
 quick_search  = "ctrl+s"
+
+# Go to path
+goto          = "ctrl+g"
+fuzzy_find    = ["f9", "ctrl+p"]
+bookmarks     = ["f2", "ctrl+b"]
+help          = "f1"
+theme_picker  = "ctrl+t"
+cmd_exec      = "ctrl+r"
+terminal      = "ctrl+o"

--- a/config.example.toml
+++ b/config.example.toml
@@ -12,6 +12,10 @@ theme = "catppuccin-mocha"
 enter_action = "edit"
 # What Space does on a file: "preview" or "edit"
 space_action = "preview"
+# Whether to ask for confirmation before executing a file.
+confirm_execute = true
+# Whether to pause and wait after execution before returning to Midday Commander.
+pause_after_execute = false
 
 # ─── Key Bindings ────────────────────────────────
 # Each binding can be a single string or a list of strings.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -36,12 +36,13 @@ const (
 
 // Dialog tags identify which operation triggered the dialog.
 const (
-	tagCopy   = "copy"
-	tagMove   = "move"
-	tagDelete = "delete"
-	tagMkdir  = "mkdir"
-	tagRename = "rename"
-	tagGoTo   = "goto"
+	tagCopy    = "copy"
+	tagMove    = "move"
+	tagDelete  = "delete"
+	tagMkdir   = "mkdir"
+	tagRename  = "rename"
+	tagGoTo    = "goto"
+	tagExecute = "execute"
 )
 
 // Model is the root application model.
@@ -71,8 +72,9 @@ type Model struct {
 	bookmarkStore *bookmark.Store
 
 	// Pending operation state (saved while dialog is open)
-	pendingSources []string
-	pendingDest    string
+	pendingSources     []string
+	pendingDest        string
+	pendingExecutePath string
 
 	// Double-Esc to quit
 	lastEsc time.Time
@@ -254,7 +256,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.fileActionCmd(msg.Path, m.cfg.Behavior.EnterAction)
 
 	case panel.ExecuteFileMsg:
-		return m, executeFileCmd(msg.Path, m.activePanel().Path())
+		if m.cfg.Behavior.ConfirmExecute == nil || *m.cfg.Behavior.ConfirmExecute {
+			m.pendingExecutePath = msg.Path
+			d := dialog.NewConfirm("Execute file", fmt.Sprintf("Run %s?", filepath.Base(msg.Path)), tagExecute)
+			m.dialog = &d
+			return m, nil
+		}
+		return m, executeFileCmd(msg.Path, m.activePanel().Path(), m.cfg.Behavior.PauseAfterExecute)
 
 	case panel.PreviewFileMsg:
 		return m, m.fileActionCmd(msg.Path, m.cfg.Behavior.SpaceAction)
@@ -727,6 +735,10 @@ func (m Model) handleDialogResult(result dialog.Result) (tea.Model, tea.Cmd) {
 			}
 			m.activePanel().SetPath(path)
 			return m, m.activePanel().LoadDir()
+		}
+	case tagExecute:
+		if result.Confirmed {
+			return m, executeFileCmd(m.pendingExecutePath, m.activePanel().Path(), m.cfg.Behavior.PauseAfterExecute)
 		}
 	}
 	return m, nil

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -100,10 +100,10 @@ func New() Model {
 
 	panelKM := panelKeyMapFromConfig(cfg.Keys)
 
-	left := panel.New(lfs, cwd, panelKM)
+	left := panel.New(lfs, cwd, panelKM, cfg)
 	left.SetActive(true)
 
-	right := panel.New(lfs, home, panelKM)
+	right := panel.New(lfs, home, panelKM, cfg)
 
 	th := theme.Default()
 	if cfg.Theme != "" {
@@ -252,6 +252,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// File action messages from panel (configurable behavior)
 	case panel.OpenFileMsg:
 		return m, m.fileActionCmd(msg.Path, m.cfg.Behavior.EnterAction)
+
+	case panel.ExecuteFileMsg:
+		return m, executeFileCmd(msg.Path, m.activePanel().Path())
 
 	case panel.PreviewFileMsg:
 		return m, m.fileActionCmd(msg.Path, m.cfg.Behavior.SpaceAction)
@@ -436,6 +439,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.keyMap.CmdExec):
 			return m.startCmdExec()
+		case key.Matches(msg, m.keyMap.Terminal):
+			return m, startTerminalCmd(m.activePanel().Path())
 		}
 
 		// Delegate to active panel
@@ -524,6 +529,8 @@ func (m Model) dispatchKey(raw string) (tea.Model, tea.Cmd) {
 		return m.startThemePicker()
 	case contains(cfg.CmdExec, raw):
 		return m.startCmdExec()
+	case contains(cfg.Terminal, raw):
+		return m, startTerminalCmd(m.activePanel().Path())
 	}
 	return m, nil
 }

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -78,6 +78,68 @@ func editFileCmd(path string) tea.Cmd {
 	})
 }
 
+func executeFileCmd(path string, dir string) tea.Cmd {
+	c := exec.Command(path)
+	c.Dir = dir
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		return externalDoneMsg{err: err}
+	})
+}
+
+func startTerminalCmd(dir string) tea.Cmd {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "bash"
+	}
+	c := interactiveShellCmd(shell)
+	c.Dir = dir
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		return externalDoneMsg{err: err}
+	})
+}
+
+func interactiveShellCmd(shellPath string) *exec.Cmd {
+	name := filepath.Base(shellPath)
+	switch name {
+	case "bash":
+		if rcFile, err := writeBashRc(); err == nil {
+			return exec.Command(shellPath, "--rcfile", rcFile, "-i")
+		}
+	case "zsh":
+		if dir, err := writeZshDir(); err == nil {
+			cmd := exec.Command(shellPath, "-i")
+			cmd.Env = append(os.Environ(), "ZDOTDIR="+dir)
+			return cmd
+		}
+	}
+	return exec.Command(shellPath, "-i")
+}
+
+func writeBashRc() (string, error) {
+	f, err := os.CreateTemp("", "mdc-terminal-*.bashrc")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	_, err = f.WriteString(`bind '"\C-o": "\C-d"'` + "\n")
+	if err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func writeZshDir() (string, error) {
+	dir, err := os.MkdirTemp("", "mdc-terminal-*")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, ".zshrc")
+	if err := os.WriteFile(path, []byte("bindkey '^O' exit\n"), 0o600); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
 // refreshBothPanels returns commands to reload both panels.
 func (m *Model) refreshBothPanels() tea.Cmd {
 	return tea.Batch(m.leftPanel.LoadDir(), m.rightPanel.LoadDir())

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -78,12 +80,40 @@ func editFileCmd(path string) tea.Cmd {
 	})
 }
 
-func executeFileCmd(path string, dir string) tea.Cmd {
+func executeFileCmd(path string, dir string, pause bool) tea.Cmd {
+	if pause {
+		shell := os.Getenv("SHELL")
+		if shell == "" {
+			shell = "bash"
+		}
+		c := pauseExecutionCmd(shell, path)
+		c.Dir = dir
+		return tea.ExecProcess(c, func(err error) tea.Msg {
+			return externalDoneMsg{err: err}
+		})
+	}
+
 	c := exec.Command(path)
 	c.Dir = dir
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return externalDoneMsg{err: err}
 	})
+}
+
+func pauseExecutionCmd(shellPath, path string) *exec.Cmd {
+	escapedPath := shellQuote(path)
+	shellName := filepath.Base(shellPath)
+	if shellName == "bash" || shellName == "zsh" {
+		script := fmt.Sprintf("status=0; %s || status=$?; printf '\nPress any key to continue...'; read -n1 -s; exit $status", escapedPath)
+		return exec.Command(shellPath, "-lc", script)
+	}
+
+	script := fmt.Sprintf("status=0; %s || status=$?; printf '\nPress enter to continue...'; read -r; exit $status", escapedPath)
+	return exec.Command(shellPath, "-c", script)
+}
+
+func shellQuote(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", "'\\''") + "'"
 }
 
 func startTerminalCmd(dir string) tea.Cmd {

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -8,20 +8,20 @@ import (
 
 // KeyMap defines all global keybindings.
 type KeyMap struct {
-	Quit        key.Binding
-	TogglePanel key.Binding
-	SwapPanels  key.Binding
-	Copy        key.Binding
-	Move        key.Binding
-	Mkdir       key.Binding
-	Delete      key.Binding
-	Rename      key.Binding
-	View        key.Binding
-	Edit        key.Binding
-	GoTo        key.Binding
-	FuzzyFind   key.Binding
-	Bookmarks   key.Binding
-	Help        key.Binding
+	Quit         key.Binding
+	TogglePanel  key.Binding
+	SwapPanels   key.Binding
+	Copy         key.Binding
+	Move         key.Binding
+	Mkdir        key.Binding
+	Delete       key.Binding
+	Rename       key.Binding
+	View         key.Binding
+	Edit         key.Binding
+	GoTo         key.Binding
+	FuzzyFind    key.Binding
+	Bookmarks    key.Binding
+	Help         key.Binding
 	ThemePicker  key.Binding
 	CmdExec      key.Binding
 	Terminal     key.Binding
@@ -31,20 +31,20 @@ type KeyMap struct {
 // KeyMapFromConfig builds the global keymap from config.
 func KeyMapFromConfig(keys config.KeyBindings) KeyMap {
 	return KeyMap{
-		Quit:        binding(keys.Quit, "quit"),
-		TogglePanel: binding(keys.TogglePanel, "switch panel"),
-		SwapPanels:  binding(keys.SwapPanels, "swap panels"),
-		Copy:        binding(keys.Copy, "copy"),
-		Move:        binding(keys.Move, "move"),
-		Mkdir:       binding(keys.Mkdir, "mkdir"),
-		Delete:      binding(keys.Delete, "delete"),
-		Rename:      binding(keys.Rename, "rename"),
-		View:        binding(keys.View, "view"),
-		Edit:        binding(keys.Edit, "edit"),
-		GoTo:        binding(keys.GoTo, "go to"),
-		FuzzyFind:   binding(keys.FuzzyFind, "find"),
-		Bookmarks:   binding(keys.Bookmarks, "bookmarks"),
-		Help:        binding(keys.Help, "help"),
+		Quit:         binding(keys.Quit, "quit"),
+		TogglePanel:  binding(keys.TogglePanel, "switch panel"),
+		SwapPanels:   binding(keys.SwapPanels, "swap panels"),
+		Copy:         binding(keys.Copy, "copy"),
+		Move:         binding(keys.Move, "move"),
+		Mkdir:        binding(keys.Mkdir, "mkdir"),
+		Delete:       binding(keys.Delete, "delete"),
+		Rename:       binding(keys.Rename, "rename"),
+		View:         binding(keys.View, "view"),
+		Edit:         binding(keys.Edit, "edit"),
+		GoTo:         binding(keys.GoTo, "go to"),
+		FuzzyFind:    binding(keys.FuzzyFind, "find"),
+		Bookmarks:    binding(keys.Bookmarks, "bookmarks"),
+		Help:         binding(keys.Help, "help"),
 		ThemePicker:  binding(keys.ThemePicker, "themes"),
 		CmdExec:      binding(keys.CmdExec, "run cmd"),
 		Terminal:     binding(keys.Terminal, "terminal"),

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -24,6 +24,7 @@ type KeyMap struct {
 	Help        key.Binding
 	ThemePicker key.Binding
 	CmdExec     key.Binding
+	Terminal    key.Binding
 }
 
 // KeyMapFromConfig builds the global keymap from config.
@@ -45,6 +46,7 @@ func KeyMapFromConfig(keys config.KeyBindings) KeyMap {
 		Help:        binding(keys.Help, "help"),
 		ThemePicker: binding(keys.ThemePicker, "themes"),
 		CmdExec:     binding(keys.CmdExec, "run cmd"),
+		Terminal:    binding(keys.Terminal, "terminal"),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,10 @@ type BehaviorConfig struct {
 	EnterAction string `toml:"enter_action"`
 	// What Space does on a file: "preview" (default) or "edit"
 	SpaceAction string `toml:"space_action"`
+	// Whether to ask for confirmation before executing a file.
+	ConfirmExecute *bool `toml:"confirm_execute"`
+	// Whether to pause and wait after execution before returning to Midday Commander.
+	PauseAfterExecute bool `toml:"pause_after_execute"`
 }
 
 // KeyBindings defines all configurable key bindings.
@@ -85,14 +89,20 @@ func (s *StringOrList) UnmarshalTOML(data any) error {
 }
 
 // Default returns a config with all defaults.
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func Default() Config {
 	keys := DefaultKeyBindings()
 	normalizeAllKeys(&keys)
 	return Config{
 		Theme: "",
 		Behavior: BehaviorConfig{
-			EnterAction: "edit",
-			SpaceAction: "preview",
+			EnterAction:       "edit",
+			SpaceAction:       "preview",
+			ConfirmExecute:    boolPtr(true),
+			PauseAfterExecute: false,
 		},
 		Keys: keys,
 	}
@@ -159,6 +169,10 @@ func Load() Config {
 	if fileCfg.Behavior.SpaceAction != "" {
 		cfg.Behavior.SpaceAction = fileCfg.Behavior.SpaceAction
 	}
+	if fileCfg.Behavior.ConfirmExecute != nil {
+		cfg.Behavior.ConfirmExecute = fileCfg.Behavior.ConfirmExecute
+	}
+	cfg.Behavior.PauseAfterExecute = fileCfg.Behavior.PauseAfterExecute
 
 	mergeKeys(&cfg.Keys, &fileCfg.Keys)
 	normalizeAllKeys(&cfg.Keys)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 
 // BehaviorConfig controls configurable behaviors.
 type BehaviorConfig struct {
-	// What Enter does on a file: "edit" (default) or "preview"
+	// What Enter does on a file: "edit" (default), "preview", or "execute"
 	EnterAction string `toml:"enter_action"`
 	// What Space does on a file: "preview" (default) or "edit"
 	SpaceAction string `toml:"space_action"`
@@ -58,12 +58,13 @@ type KeyBindings struct {
 	QuickSearch StringOrList `toml:"quick_search"`
 
 	// Go to path
-	GoTo       StringOrList `toml:"goto"`
-	FuzzyFind  StringOrList `toml:"fuzzy_find"`
-	Bookmarks  StringOrList `toml:"bookmarks"`
+	GoTo        StringOrList `toml:"goto"`
+	FuzzyFind   StringOrList `toml:"fuzzy_find"`
+	Bookmarks   StringOrList `toml:"bookmarks"`
 	Help        StringOrList `toml:"help"`
 	ThemePicker StringOrList `toml:"theme_picker"`
 	CmdExec     StringOrList `toml:"cmd_exec"`
+	Terminal    StringOrList `toml:"terminal"`
 }
 
 // StringOrList can unmarshal from either a single string or a list of strings.
@@ -125,13 +126,12 @@ func DefaultKeyBindings() KeyBindings {
 
 		QuickSearch: StringOrList{"ctrl+s"},
 
-		GoTo:      StringOrList{"ctrl+g"},
-		FuzzyFind: StringOrList{"f9", "ctrl+p"},
-		Bookmarks: StringOrList{"f2", "ctrl+b"},
+		GoTo:        StringOrList{"ctrl+g"},
+		FuzzyFind:   StringOrList{"f9", "ctrl+p"},
+		Bookmarks:   StringOrList{"f2", "ctrl+b"},
 		Help:        StringOrList{"f1"},
 		ThemePicker: StringOrList{"ctrl+t"},
-		CmdExec:     StringOrList{"ctrl+r"},
-	}
+		CmdExec:     StringOrList{"ctrl+r"}, Terminal: StringOrList{"ctrl+o"}}
 }
 
 // Load reads config from ~/.config/mdc/config.toml, merging with defaults.
@@ -194,6 +194,7 @@ func mergeKeys(dst, src *KeyBindings) {
 	mergeKey(&dst.Help, src.Help)
 	mergeKey(&dst.ThemePicker, src.ThemePicker)
 	mergeKey(&dst.CmdExec, src.CmdExec)
+	mergeKey(&dst.Terminal, src.Terminal)
 }
 
 func mergeKey(dst *StringOrList, src StringOrList) {
@@ -250,6 +251,7 @@ func normalizeAllKeys(kb *KeyBindings) {
 	normalizeSlice(&kb.Help)
 	normalizeSlice(&kb.ThemePicker)
 	normalizeSlice(&kb.CmdExec)
+	normalizeSlice(&kb.Terminal)
 }
 
 // SaveTheme writes the theme name to the config file, preserving other settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,10 +62,10 @@ type KeyBindings struct {
 	QuickSearch StringOrList `toml:"quick_search"`
 
 	// Go to path
-	GoTo        StringOrList `toml:"goto"`
-	FuzzyFind   StringOrList `toml:"fuzzy_find"`
-	Bookmarks   StringOrList `toml:"bookmarks"`
-	Help        StringOrList `toml:"help"`
+	GoTo         StringOrList `toml:"goto"`
+	FuzzyFind    StringOrList `toml:"fuzzy_find"`
+	Bookmarks    StringOrList `toml:"bookmarks"`
+	Help         StringOrList `toml:"help"`
 	ThemePicker  StringOrList `toml:"theme_picker"`
 	CmdExec      StringOrList `toml:"cmd_exec"`
 	Terminal     StringOrList `toml:"terminal"`
@@ -137,13 +137,13 @@ func DefaultKeyBindings() KeyBindings {
 
 		QuickSearch: StringOrList{"ctrl+s"},
 
-		GoTo:        StringOrList{"ctrl+g"},
-		FuzzyFind:   StringOrList{"f9", "ctrl+p"},
-		Bookmarks:   StringOrList{"f2", "ctrl+b"},
-		Help:        StringOrList{"f1"},
-		ThemePicker: StringOrList{"ctrl+t"},
-		CmdExec:     StringOrList{"ctrl+r"},
-		Terminal:    StringOrList{"ctrl+o"},
+		GoTo:         StringOrList{"ctrl+g"},
+		FuzzyFind:    StringOrList{"f9", "ctrl+p"},
+		Bookmarks:    StringOrList{"f2", "ctrl+b"},
+		Help:         StringOrList{"f1"},
+		ThemePicker:  StringOrList{"ctrl+t"},
+		CmdExec:      StringOrList{"ctrl+r"},
+		Terminal:     StringOrList{"ctrl+o"},
 		ToggleHidden: StringOrList{"ctrl+h"},
 	}
 }

--- a/internal/ui/help/help.go
+++ b/internal/ui/help/help.go
@@ -98,6 +98,7 @@ func (m Model) buildEntries() []entry {
 		{"Quick search", fmtKeys(k.QuickSearch)},
 		{"Theme picker", fmtKeys(k.ThemePicker)},
 		{"Run command", fmtKeys(k.CmdExec)},
+		{"Terminal", fmtKeys(k.Terminal)},
 		{"Help", fmtKeys(k.Help)},
 		{"Quit", fmtKeys(k.Quit)},
 	}

--- a/internal/ui/panel/panel.go
+++ b/internal/ui/panel/panel.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/kooler/MiddayCommander/internal/config"
 	"github.com/kooler/MiddayCommander/internal/vfs"
 	"github.com/kooler/MiddayCommander/internal/vfs/archive"
 )
@@ -42,6 +43,8 @@ type Model struct {
 	active   bool
 	err      error
 
+	cfg config.Config // application config
+
 	// Quick search state
 	searching   bool
 	searchQuery string
@@ -57,13 +60,14 @@ type Model struct {
 }
 
 // New creates a new panel browsing the given directory.
-func New(filesystem vfs.FS, path string, km KeyMap) Model {
+func New(filesystem vfs.FS, path string, km KeyMap, cfg config.Config) Model {
 	return Model{
 		fs:       filesystem,
 		path:     path,
 		selected: make(map[int]bool),
 		sortMode: SortByName,
 		keyMap:   km,
+		cfg:      cfg,
 	}
 }
 
@@ -381,8 +385,12 @@ func (m *Model) handleEnter() tea.Cmd {
 		}
 	}
 
-	// Enter on file = open for edit
+	// Enter on file
 	path := m.CurrentPath()
+	info := m.infos[m.cursor]
+	if info != nil && isExecutable(info.Mode()) && m.cfg.Behavior.EnterAction == "execute" {
+		return func() tea.Msg { return ExecuteFileMsg{Path: path} }
+	}
 	return func() tea.Msg { return OpenFileMsg{Path: path} }
 }
 
@@ -499,6 +507,11 @@ type RestoreCursorMsg struct {
 
 // OpenFileMsg is sent when the user wants to open a file (Enter on file).
 type OpenFileMsg struct {
+	Path string
+}
+
+// ExecuteFileMsg is sent when the user wants to execute a file (Enter on executable file).
+type ExecuteFileMsg struct {
 	Path string
 }
 

--- a/internal/ui/panel/panel.go
+++ b/internal/ui/panel/panel.go
@@ -387,7 +387,7 @@ func (m *Model) handleEnter() tea.Cmd {
 
 	// Enter on file
 	path := m.CurrentPath()
-	info := m.infos[m.cursor]
+	info := m.CurrentInfo()
 	if info != nil && isExecutable(info.Mode()) && m.cfg.Behavior.EnterAction == "execute" {
 		return func() tea.Msg { return ExecuteFileMsg{Path: path} }
 	}


### PR DESCRIPTION
## Pull Request Description

### Description

This PR adds two major usability improvements to MiddayCommander, inspired by Midnight Commander:

1. **Configurable Enter Key Execution**: Allow pressing Enter on executable files to run them directly instead of opening in editor
2. **Terminal Console Access**: Add Ctrl+O key binding to open a shell in the current directory with return capability

### Changes

#### Configuration
- Added `"execute"` option to `enter_action` in `behavior` config section
- Added `terminal` key binding (defaults to `ctrl+o`)

#### Core Features
- **Enter Execution**: When `enter_action = "execute"`, pressing Enter on executable files runs them in foreground
- **Terminal Access**: Ctrl+O opens interactive shell in current panel directory
- **Shell Return**: Ctrl+O in the shell exits back to MiddayCommander (works with bash/zsh)

#### Files Modified
- `internal/config/config.go`: Added config options and key bindings
- `internal/ui/panel/panel.go`: Modified Enter handling for executables
- `internal/app/app.go`: Added message handling and key dispatch
- `internal/app/commands.go`: Implemented execution and terminal commands
- `internal/app/keymap.go`: Added terminal key binding
- `internal/ui/help/help.go`: Updated help documentation
- `README.md`: Updated features and config docs
- `config.example.toml`: Added new options

### Configuration

Add to `~/.config/mdc/config.toml`:

```toml
[behavior]
enter_action = "execute"  # Options: "edit", "preview", "execute"

[keys]
terminal = "ctrl+o"  # Open terminal
```

### Testing

1. **Enter Execution**:
   - Set `enter_action = "execute"` in config
   - Navigate to an executable file (e.g., script with execute permissions)
   - Press Enter → should run the file in terminal
   - Press Enter on non-executables → should still edit/preview as before

2. **Terminal Access**:
   - Press Ctrl+O → opens shell in current directory
   - Press Ctrl+O in shell → returns to MiddayCommander
   - Directory changes in shell don't affect panel (standard mc behavior)

3. **Help**:
   - Press F1 → should show "Terminal" in Tools section

### Motivation

Addresses user pain points with script execution convenience:
- Eliminates need for Ctrl+R + typing command for simple script execution
- Provides familiar mc-style terminal access
- Maintains backward compatibility with existing workflows

### Screenshots

N/A - Terminal application, functionality can be tested via described steps.

### Checklist
- [x] Code compiles without errors
- [x] Backward compatible (existing configs work)
- [x] Help documentation updated
- [x] Config examples updated
- [x] Tested with bash and zsh shells
- [x] Follows existing code patterns and style
