### PR TITLE
feat: hide cursor highlight on inactive panels

### DIFF
--- a/internal/ui/panel/panel_view.go
+++ b/internal/ui/panel/panel_view.go
@@ -91,7 +91,7 @@ func (m Model) renderRow(idx, width int, th theme.Theme) string {
 
 	name := entry.Name()
 	isDir := entry.IsDir()
-	isCursor := idx == m.cursor
+	isCursor := idx == m.cursor && m.active
 	isSelected := m.selected[idx]
 
 	// Determine columns: name, size, time


### PR DESCRIPTION
## Pull Request Description

### Description

This PR improves the visual clarity of the dual-panel interface by only showing cursor highlighting on the active panel. Previously, both panels displayed highlighted items, making it confusing to see which panel was focused.

### Changes

#### UI Improvement
- Modified `internal/ui/panel/panel_view.go` to only highlight the cursor on active panels
- Inactive panels now display normally without cursor highlighting
- Matches Midnight Commander's behavior for better user experience

#### Files Modified
- `internal/ui/panel/panel_view.go`: Updated `renderRow()` to check `m.active` before setting cursor highlight

### Testing

1. **Panel Focus**:
   - Switch between panels with Tab
   - Only the active panel should show cursor highlighting
   - Inactive panel should display normally without highlights

2. **Navigation**:
   - Cursor movement (up/down) only affects the active panel
   - Visual feedback clearly indicates which panel is controlled

### Motivation

Addresses visual confusion in dual-panel interface:
- Eliminates ambiguity about which panel has focus
- Provides clearer visual feedback for panel switching
- Improves user experience to match established file manager conventions

### Screenshots

N/A - Visual change in terminal interface, test by switching panels.

### Checklist
- [x] Code compiles without errors
- [x] Backward compatible (no config changes needed)
- [x] Follows existing code patterns
- [x] Improves user experience
- [x] Matches MC behavior
