### PR TITLE
Add toggle hidden files shortcut (Ctrl+H)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -436,6 +436,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.keyMap.CmdExec):
 			return m.startCmdExec()
+
+		case key.Matches(msg, m.keyMap.ToggleHidden):
+			m.leftPanel.ToggleHidden()
+			m.rightPanel.ToggleHidden()
+			return m, m.refreshBothPanels()
 		}
 
 		// Delegate to active panel

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -22,8 +22,9 @@ type KeyMap struct {
 	FuzzyFind   key.Binding
 	Bookmarks   key.Binding
 	Help        key.Binding
-	ThemePicker key.Binding
-	CmdExec     key.Binding
+	ThemePicker  key.Binding
+	CmdExec      key.Binding
+	ToggleHidden key.Binding
 }
 
 // KeyMapFromConfig builds the global keymap from config.
@@ -43,8 +44,9 @@ func KeyMapFromConfig(keys config.KeyBindings) KeyMap {
 		FuzzyFind:   binding(keys.FuzzyFind, "find"),
 		Bookmarks:   binding(keys.Bookmarks, "bookmarks"),
 		Help:        binding(keys.Help, "help"),
-		ThemePicker: binding(keys.ThemePicker, "themes"),
-		CmdExec:     binding(keys.CmdExec, "run cmd"),
+		ThemePicker:  binding(keys.ThemePicker, "themes"),
+		CmdExec:      binding(keys.CmdExec, "run cmd"),
+		ToggleHidden: binding(keys.ToggleHidden, "toggle hidden"),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,8 +62,9 @@ type KeyBindings struct {
 	FuzzyFind  StringOrList `toml:"fuzzy_find"`
 	Bookmarks  StringOrList `toml:"bookmarks"`
 	Help        StringOrList `toml:"help"`
-	ThemePicker StringOrList `toml:"theme_picker"`
-	CmdExec     StringOrList `toml:"cmd_exec"`
+	ThemePicker  StringOrList `toml:"theme_picker"`
+	CmdExec      StringOrList `toml:"cmd_exec"`
+	ToggleHidden StringOrList `toml:"toggle_hidden"`
 }
 
 // StringOrList can unmarshal from either a single string or a list of strings.
@@ -129,8 +130,9 @@ func DefaultKeyBindings() KeyBindings {
 		FuzzyFind: StringOrList{"f9", "ctrl+p"},
 		Bookmarks: StringOrList{"f2", "ctrl+b"},
 		Help:        StringOrList{"f1"},
-		ThemePicker: StringOrList{"ctrl+t"},
-		CmdExec:     StringOrList{"ctrl+r"},
+		ThemePicker:  StringOrList{"ctrl+t"},
+		CmdExec:      StringOrList{"ctrl+r"},
+		ToggleHidden: StringOrList{"ctrl+h"},
 	}
 }
 
@@ -194,6 +196,7 @@ func mergeKeys(dst, src *KeyBindings) {
 	mergeKey(&dst.Help, src.Help)
 	mergeKey(&dst.ThemePicker, src.ThemePicker)
 	mergeKey(&dst.CmdExec, src.CmdExec)
+	mergeKey(&dst.ToggleHidden, src.ToggleHidden)
 }
 
 func mergeKey(dst *StringOrList, src StringOrList) {
@@ -250,6 +253,7 @@ func normalizeAllKeys(kb *KeyBindings) {
 	normalizeSlice(&kb.Help)
 	normalizeSlice(&kb.ThemePicker)
 	normalizeSlice(&kb.CmdExec)
+	normalizeSlice(&kb.ToggleHidden)
 }
 
 // SaveTheme writes the theme name to the config file, preserving other settings.

--- a/internal/ui/panel/panel.go
+++ b/internal/ui/panel/panel.go
@@ -29,18 +29,19 @@ type KeyMap struct {
 
 // Model represents a single file panel.
 type Model struct {
-	fs       vfs.FS
-	path     string        // absolute path of current directory
-	entries  []fs.DirEntry // directory contents (sorted)
-	infos    []fs.FileInfo // cached FileInfo for each entry
-	cursor   int           // highlighted entry index
-	offset   int           // scroll offset for viewport
-	selected map[int]bool  // tagged/selected entries
-	sortMode SortMode
-	width    int
-	height   int // height available for file list rows
-	active   bool
-	err      error
+	fs         vfs.FS
+	path       string        // absolute path of current directory
+	entries    []fs.DirEntry // directory contents (sorted)
+	infos      []fs.FileInfo // cached FileInfo for each entry
+	cursor     int           // highlighted entry index
+	offset     int           // scroll offset for viewport
+	selected   map[int]bool  // tagged/selected entries
+	sortMode   SortMode
+	showHidden bool // whether to show dotfiles
+	width      int
+	height     int // height available for file list rows
+	active     bool
+	err        error
 
 	// Quick search state
 	searching   bool
@@ -59,12 +60,23 @@ type Model struct {
 // New creates a new panel browsing the given directory.
 func New(filesystem vfs.FS, path string, km KeyMap) Model {
 	return Model{
-		fs:       filesystem,
-		path:     path,
-		selected: make(map[int]bool),
-		sortMode: SortByName,
-		keyMap:   km,
+		fs:         filesystem,
+		path:       path,
+		selected:   make(map[int]bool),
+		sortMode:   SortByName,
+		showHidden: true,
+		keyMap:     km,
 	}
+}
+
+// ToggleHidden flips whether dotfiles are shown.
+func (m *Model) ToggleHidden() {
+	m.showHidden = !m.showHidden
+}
+
+// ShowHidden returns the current hidden-file visibility state.
+func (m Model) ShowHidden() bool {
+	return m.showHidden
 }
 
 // Path returns the current directory path.
@@ -202,7 +214,12 @@ func (m *Model) HandleDirLoaded(msg DirLoadedMsg) {
 	if !isRootPath(m.path) {
 		all = append(all, parentEntry{})
 	}
-	all = append(all, msg.Entries...)
+	for _, e := range msg.Entries {
+		if !m.showHidden && strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		all = append(all, e)
+	}
 
 	SortEntries(all, m.sortMode)
 	m.entries = all

--- a/internal/ui/panel/panel_view.go
+++ b/internal/ui/panel/panel_view.go
@@ -71,7 +71,11 @@ func (m Model) View(th theme.Theme) string {
 		if m.entries != nil && !isRootPath(m.path) {
 			count-- // exclude ".."
 		}
-		footerText = fmt.Sprintf(" %d files ", count)
+		if m.showHidden {
+			footerText = fmt.Sprintf(" %d files ", count)
+		} else {
+			footerText = fmt.Sprintf(" %d files [.hidden] ", count)
+		}
 	}
 	footerLine := borderStyle.Render("└") +
 		headerStyle.Render(truncOrPad(footerText, innerWidth)) +


### PR DESCRIPTION
## Summary

- Adds a `toggle_hidden` key binding (default `Ctrl+H`) that shows or hides dotfiles and dot-directories in both panels simultaneously
- When hidden files are filtered, the panel footer displays `[.hidden]` so the state is always visible
- The binding is fully configurable via `config.toml` (`toggle_hidden = "ctrl+h"`)

## Motivation

Directories can be cluttered with dotfiles (`.git`, `.cache`, `.config`, etc.) that get in the way of everyday file management. This gives users a quick way to declutter the view without leaving the app.

## Notes

This feature was developed with assistance from [Claude Code](https://claude.ai/code) (Anthropic's AI coding tool). I found it genuinely useful for my own workflow but wanted to be transparent — feel free to reject this PR if AI-assisted contributions are a concern for the project.

🤖 Generated with [Claude Code](https://claude.ai/code)