### PR TITLE
Add view_mode config option to open files with system default viewer

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -557,6 +557,9 @@ func (m *Model) fileActionCmd(path string, action string) tea.Cmd {
 	case "edit":
 		return editFileCmd(path)
 	case "preview":
+		if m.cfg.Behavior.ViewMode == "system" {
+			return openSystemDefaultCmd(path)
+		}
 		return viewFileCmd(path)
 	default:
 		return editFileCmd(path)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -675,7 +675,11 @@ func (m Model) startView() (tea.Model, tea.Cmd) {
 	if e == nil || e.IsDir() {
 		return m, nil
 	}
-	return m, viewFileCmd(m.currentFilePath())
+	path := m.currentFilePath()
+	if m.cfg.Behavior.ViewMode == "system" {
+		return m, openSystemDefaultCmd(path)
+	}
+	return m, viewFileCmd(path)
 }
 
 func (m Model) startEdit() (tea.Model, tea.Cmd) {

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -65,6 +66,22 @@ func viewFileCmd(path string) tea.Cmd {
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return externalDoneMsg{err: err}
 	})
+}
+
+func openSystemDefaultCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		var c *exec.Cmd
+		switch runtime.GOOS {
+		case "darwin":
+			c = exec.Command("open", path)
+		case "windows":
+			c = exec.Command("explorer", path)
+		default:
+			c = exec.Command("xdg-open", path)
+		}
+		_ = c.Start()
+		return externalDoneMsg{}
+	}
 }
 
 func editFileCmd(path string) tea.Cmd {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,8 @@ type BehaviorConfig struct {
 	EnterAction string `toml:"enter_action"`
 	// What Space does on a file: "preview" (default) or "edit"
 	SpaceAction string `toml:"space_action"`
+	// ViewMode controls how F3 opens files: "pager" (default, uses $PAGER/less) or "system" (OS default app)
+	ViewMode string `toml:"view_mode"`
 }
 
 // KeyBindings defines all configurable key bindings.
@@ -93,6 +95,7 @@ func Default() Config {
 		Behavior: BehaviorConfig{
 			EnterAction: "edit",
 			SpaceAction: "preview",
+			ViewMode:    "pager",
 		},
 		Keys: keys,
 	}
@@ -160,6 +163,9 @@ func Load() Config {
 	}
 	if fileCfg.Behavior.SpaceAction != "" {
 		cfg.Behavior.SpaceAction = fileCfg.Behavior.SpaceAction
+	}
+	if fileCfg.Behavior.ViewMode != "" {
+		cfg.Behavior.ViewMode = fileCfg.Behavior.ViewMode
 	}
 
 	mergeKeys(&cfg.Keys, &fileCfg.Keys)


### PR DESCRIPTION
## Summary

- Adds a `view_mode` setting under `[behavior]` in `config.toml` with two values:
  - `"pager"` (default) — existing behaviour, opens in `$PAGER`/`less`
  - `"system"` — opens the file using the OS default application (`xdg-open` on Linux, `open` on macOS, `explorer` on Windows)
- Fully backward-compatible: the default is `"pager"` so nothing changes unless the user opts in

## Motivation

The F3 (View) key currently always opens files in a terminal pager, which is useless — or even broken — for binary and non-text formats like images, videos, PDFs, or office documents. With `view_mode = "system"`, pressing F3 hands the file off to whatever the OS has registered for that extension, so an image opens in an image viewer, a PDF in a PDF reader, and so on, without leaving mdc.

**Usage:**

```toml
[behavior]
view_mode = "system"
```

## Notes

This feature was developed with assistance from [Claude Code](https://claude.ai/code) (Anthropic's AI coding tool). I found it genuinely useful for my own workflow but wanted to be transparent — feel free to reject this PR if AI-assisted contributions are a concern for the project.

🤖 Generated with [Claude Code](https://claude.ai/code)