### PR TITLE
feat: added the Tokyo Night theme

### DIFF
--- a/themes/tokyo-night.toml
+++ b/themes/tokyo-night.toml
@@ -1,36 +1,75 @@
 name = "Tokyo Night"
 
 [palette]
-bg     = "#1a1b26"
-fg     = "#c0caf5"
-blue   = "#7aa2f7"
-green  = "#9ece6a"
-cyan   = "#7dcfff"
-purple = "#bb9af7"
-red    = "#f7768e"
-yellow = "#e0af68"
+red       = "#f7768e"
+orange    = "#ff9e64"
+yellow    = "#e0af68"
+green     = "#9ece6a"
+teal      = "#73daca"
+cyan      = "#7dcfff"
+blue      = "#7aa2f7"
+purple    = "#bb9af7"
+magenta   = "#c0caf5"
 
+fg        = "#c0caf5"
+fg_dark   = "#a9b1d6"
+comment   = "#565f89"
+
+bg        = "#1a1b26"
+bg_dark   = "#16161e"
+bg_high   = "#24283b"
+bg_float  = "#1f2335"
+
+border    = "#3b4261"
+selection = "#33467c"
+black     = "#15161e"
+
+# ─── File Panels ─────────────────────────────────
 [panel]
-border_fg        = "blue"
+border_fg        = "border"
 border_bg        = "bg"
-border_active_fg = "fg"
+border_active_fg = "blue"
 border_active_bg = "bg"
+header_fg        = "comment"
+header_bg        = "bg"
+header_active_fg = "cyan"
+header_active_bg = "bg"
 
 [panel.file]
-normal_fg  = "fg"
-normal_bg  = "bg"
-dir_fg     = "blue"
-dir_bold   = true
-exec_fg    = "green"
+normal_fg        = "fg"
+normal_bg        = "bg"
 
+dir_fg           = "blue"
+dir_bg           = "bg"
+dir_bold         = true
+
+exec_fg          = "green"
+exec_bg          = "bg"
+
+symlink_fg       = "purple"
+symlink_bg       = "bg"
+
+cursor_fg        = "black"
+cursor_bg        = "cyan"
+
+cursor_dir_fg    = "black"
+cursor_dir_bg    = "blue"
+cursor_dir_bold  = true
+
+selected_fg      = "yellow"
+selected_bg      = "bg_high"
+selected_bold    = true
+
+# ─── Status Bar ──────────────────────────────────
 [statusbar]
-fg = "bg"
+fg = "black"
 bg = "blue"
 
+# ─── Menu / F-Key Hints ─────────────────────────
 [menubar]
-fg            = "bg"
-bg            = "blue"
-fkey_hint_fg  = "fg"
-fkey_hint_bg  = "bg"
-fkey_label_fg = "bg"
-fkey_label_bg = "blue"
+fg            = "fg"
+bg            = "bg_high"
+fkey_hint_fg  = "fg_dark"
+fkey_hint_bg  = "bg_dark"
+fkey_label_fg = "fg"
+fkey_label_bg = "bg_high"

--- a/themes/tokyo-night.toml
+++ b/themes/tokyo-night.toml
@@ -1,0 +1,36 @@
+name = "Tokyo Night"
+
+[palette]
+bg     = "#1a1b26"
+fg     = "#c0caf5"
+blue   = "#7aa2f7"
+green  = "#9ece6a"
+cyan   = "#7dcfff"
+purple = "#bb9af7"
+red    = "#f7768e"
+yellow = "#e0af68"
+
+[panel]
+border_fg        = "blue"
+border_bg        = "bg"
+border_active_fg = "fg"
+border_active_bg = "bg"
+
+[panel.file]
+normal_fg  = "fg"
+normal_bg  = "bg"
+dir_fg     = "blue"
+dir_bold   = true
+exec_fg    = "green"
+
+[statusbar]
+fg = "bg"
+bg = "blue"
+
+[menubar]
+fg            = "bg"
+bg            = "blue"
+fkey_hint_fg  = "fg"
+fkey_hint_bg  = "bg"
+fkey_label_fg = "bg"
+fkey_label_bg = "blue"


### PR DESCRIPTION
This pull request introduces a new color theme configuration for the application. The theme, named "Tokyo Night," defines custom colors and styles for various UI components.

Theme addition:

* Added a new theme configuration file `tokyo-night.toml` with a "Tokyo Night" color palette, specifying colors for background, foreground, and accent colors such as blue, green, cyan, purple, red, and yellow.
* Defined styles for UI components including `panel`, `panel.file`, `statusbar`, and `menubar`, assigning colors from the palette to each section for consistent theming.